### PR TITLE
[530996] Revert change made to findMouseEventTargetInDescendantsAt()

### DIFF
--- a/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
+++ b/org.eclipse.draw2d/src/org/eclipse/draw2d/Figure.java
@@ -455,9 +455,7 @@ public class Figure implements IFigure {
 				if (fig.containsPoint(PRIVATE_POINT.x, PRIVATE_POINT.y)) {
 					fig = fig.findMouseEventTargetAt(PRIVATE_POINT.x,
 							PRIVATE_POINT.y);
-					if (fig != null) {
-						return fig;
-					}
+					return fig;
 				}
 			}
 		}


### PR DESCRIPTION
Reverts the change made to findMouseEventTargetInDescendantsAt() in Bug 486925 that
made it only return non-null figures. This fixes a serious regression
preventing the Snippets view in Eclipse from properly working.

Bug 530996: Snippets view broken due to changes made in findMouseEventTargetInDescendantsAt()
Signed-off-by: John Collier <John.J.Collier@ibm.com>